### PR TITLE
style: Add rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+group_imports = "StdExternalCrate"
+reorder_imports = true
+use_field_init_shorthand = true
+format_code_in_doc_comments = true
+format_macro_matchers = true
+match_block_trailing_comma = true
+overflow_delimited_expr = true


### PR DESCRIPTION
This PR adds a rustfmt.toml, setting some style preferences.

Some of them rely on nightly rustfmt, but given that we're on nightly anyways, this is fine.
