### PR TITLE
refactor(core): Rename caret to cursor everywhere the terminology was used

### DIFF
--- a/crates/bazed-core/src/buffer.rs
+++ b/crates/bazed-core/src/buffer.rs
@@ -10,22 +10,22 @@ pub struct Buffer {
     dirty: bool,
     undo_group_id: usize,
     regions: HashMap<RegionId, Region>,
-    primary_caret: RegionId,
+    primary_cursor: RegionId,
 }
 
 impl Buffer {
     pub fn open_ephemeral() -> Self {
         let rope = Rope::from(String::new());
-        let primary_caret = RegionId::gen();
+        let primary_cursor = RegionId::gen();
         let mut regions = HashMap::new();
-        regions.insert(primary_caret, Region::caret(0));
+        regions.insert(primary_cursor, Region::cursor(0));
         Self {
             dirty: false,
             undo_group_id: 1,
             engine: Engine::new(rope.clone()),
             text: rope,
             regions,
-            primary_caret,
+            primary_cursor,
         }
     }
 
@@ -63,8 +63,8 @@ impl Buffer {
     pub fn insert_at_primary(&mut self, chars: &str) {
         let region = self
             .regions
-            .get(&self.primary_caret)
-            .expect("Primary caret not found in regions");
+            .get(&self.primary_cursor)
+            .expect("Primary cursor not found in regions");
         self.do_insert(&[*region], chars)
     }
 

--- a/crates/bazed-core/src/region.rs
+++ b/crates/bazed-core/src/region.rs
@@ -23,7 +23,7 @@ impl Region {
         Self { start, end }
     }
 
-    pub fn caret(at: usize) -> Self {
+    pub fn cursor(at: usize) -> Self {
         Self::new(at, at)
     }
 
@@ -43,8 +43,8 @@ impl Region {
         self.end
     }
 
-    /// A region is considered a caret if its length is 0
-    pub fn is_caret(&self) -> bool {
+    /// A region is considered a cursor if its length is 0
+    pub fn is_cursor(&self) -> bool {
         self.start == self.end
     }
 }


### PR DESCRIPTION
This PR simply renames `caret` to `cursor` throughout our codebase.
This _should_ have been part of #18, but for some reason wheren't actually commited within that PR...
