### PR TITLE
Views into documents

### DIFF
--- a/crates/bazed-core/src/app.rs
+++ b/crates/bazed-core/src/app.rs
@@ -1,6 +1,11 @@
 use std::{collections::HashMap, sync::Arc};
 
-use bazed_rpc::{core_proto::ToBackend, core_proto::ToFrontend, server::ClientSendHandle};
+use bazed_rpc::{
+    core_proto::ToBackend,
+    core_proto::{CaretPosition, ToFrontend},
+    keycode::KeyInput,
+    server::ClientSendHandle,
+};
 use color_eyre::Result;
 use futures::StreamExt;
 use tokio::sync::RwLock;
@@ -8,11 +13,20 @@ use tokio::sync::RwLock;
 use crate::{
     document::{Document, DocumentId},
     input_mapper::interpret_key_input,
+    view::{View, ViewId},
 };
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("No document with id {0} found")]
+    InvalidDocumentId(DocumentId),
+    #[error("No view with id {0} found")]
+    InvalidViewId(ViewId),
+}
 
 pub struct App {
     documents: HashMap<DocumentId, Document>,
-    active_document: Option<DocumentId>,
+    views: HashMap<ViewId, View>,
     event_send: ClientSendHandle,
 }
 
@@ -20,22 +34,21 @@ impl App {
     pub fn new(event_send: ClientSendHandle) -> Self {
         App {
             documents: HashMap::new(),
-            active_document: None,
             event_send,
+            views: HashMap::new(),
         }
     }
 
     async fn open_document(&mut self, document: Document) -> Result<()> {
         let id = DocumentId::gen();
         self.event_send
-            .send_rpc_notification(ToFrontend::Open {
-                id: id.0,
+            .send_rpc(ToFrontend::OpenDocument {
+                document_id: id.0,
                 path: document.path.clone(),
                 text: document.buffer.content_to_string(),
             })
             .await?;
         self.documents.insert(id, document);
-        self.active_document = Some(id);
         Ok(())
     }
 
@@ -55,24 +68,80 @@ impl App {
     async fn handle_rpc_call(&mut self, call: ToBackend) -> Result<()> {
         tracing::info!(call = ?call, "Handling rpc call");
         match call {
-            ToBackend::KeyPressed(key) => {
-                let Some(document_id) = self.active_document else { return Ok(()) };
-                let Some(ref mut document) = self.documents.get_mut(&document_id) else { return Ok(()) };
-
-                let Some(operation) = interpret_key_input(&key) else {
-                    tracing::info!("Ignoring unhandled key input: {key:?}");
-                    return Ok(())
-                };
-                document.buffer.apply_buffer_op(operation);
-                self.event_send
-                    .send_rpc_notification(document.create_update_notification(document_id))
-                    .await?;
+            ToBackend::KeyPressed { view_id, input } => {
+                self.handle_key_pressed(ViewId::from_uuid(view_id), input)
+                    .await?
             },
-            ToBackend::MouseInput(coords) => {
-                tracing::info!("mouse input: {coords:?}")
+            ToBackend::MouseInput { view_id, position } => {
+                self.handle_mouse_input(ViewId::from_uuid(view_id), position)?
+            },
+            ToBackend::ViewOpened {
+                request_id,
+                document_id,
+                height,
+                width,
+            } => {
+                let view_id = self
+                    .handle_view_opened(DocumentId::from_uuid(document_id), height, width)
+                    .await?;
+                self.event_send
+                    .send_rpc(ToFrontend::ViewOpenedResponse {
+                        request_id,
+                        view_id: view_id.into(),
+                    })
+                    .await?;
             },
         }
         Ok(())
+    }
+    async fn handle_key_pressed(&mut self, view: ViewId, input: KeyInput) -> Result<()> {
+        let view = self
+            .views
+            .get_mut(&view)
+            .ok_or(Error::InvalidViewId(view))?;
+        let document = self
+            .documents
+            .get_mut(&view.document_id)
+            .ok_or(Error::InvalidDocumentId(view.document_id))?;
+
+        let Some(operation) = interpret_key_input(&input) else {
+            tracing::info!("Ignoring unhandled key input: {input:?}");
+            return Ok(())
+        };
+        document.buffer.apply_buffer_op(operation);
+        // TODO updates should be linked to views, although possibly batched?
+        self.event_send
+            .send_rpc(document.create_update_notification(view.document_id))
+            .await?;
+        Ok(())
+    }
+
+    fn handle_mouse_input(&mut self, view: ViewId, coords: CaretPosition) -> Result<()> {
+        let _view = self
+            .views
+            .get_mut(&view)
+            .ok_or(Error::InvalidViewId(view))?;
+        tracing::info!("mouse input: {coords:?}. No handling implemented so far");
+        Ok(())
+    }
+
+    async fn handle_view_opened(
+        &mut self,
+        document_id: DocumentId,
+        height: usize,
+        width: usize,
+    ) -> Result<ViewId> {
+        if !self.documents.contains_key(&document_id) {
+            return Err(Error::InvalidDocumentId(document_id).into());
+        }
+        let view = View::new(document_id, height, width);
+        let id = ViewId::gen();
+        self.views.insert(id, view);
+        Ok(id)
+    }
+
+    pub fn views(&self) -> &HashMap<ViewId, View> {
+        &self.views
     }
 }
 

--- a/crates/bazed-core/src/buffer.rs
+++ b/crates/bazed-core/src/buffer.rs
@@ -99,6 +99,17 @@ impl Buffer {
             .map(|x| Position::from_offset(&self.text, x.offset))
     }
 
+    /// get the lines in the given inclusive range
+    pub fn lines_between(
+        &self,
+        low: usize,
+        high: usize,
+    ) -> impl Iterator<Item = std::borrow::Cow<str>> {
+        // TODO lines takes a range, so this is probably a very bad way of doing this...
+        // let's look into optimizing this.
+        self.text.lines(..).skip(low).take(high - low)
+    }
+
     #[tracing::instrument(skip(self))]
     fn commit_delta(&mut self, delta: RopeDelta) -> Rope {
         let head_rev = self.engine.get_head_rev_id();

--- a/crates/bazed-core/src/document.rs
+++ b/crates/bazed-core/src/document.rs
@@ -7,9 +7,13 @@ use crate::buffer::Buffer;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, derive_more::Display, derive_more::Into)]
 pub struct DocumentId(pub Uuid);
+
 impl DocumentId {
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
     pub fn gen() -> DocumentId {
-        DocumentId(Uuid::new_v4())
+        Self(Uuid::new_v4())
     }
 }
 
@@ -49,7 +53,7 @@ impl Document {
     /// the parts of the document that are currently visible / relevant in the frontend.
     pub fn create_update_notification(&self, id: DocumentId) -> ToFrontend {
         ToFrontend::UpdateDocument {
-            id: id.0,
+            document_id: id.0,
             text: self.buffer.content_to_string(),
             carets: self
                 .buffer

--- a/crates/bazed-core/src/lib.rs
+++ b/crates/bazed-core/src/lib.rs
@@ -6,3 +6,4 @@ pub mod document;
 mod input_mapper;
 pub mod mark;
 mod user_buffer_op;
+pub mod view;

--- a/crates/bazed-core/src/view.rs
+++ b/crates/bazed-core/src/view.rs
@@ -1,0 +1,58 @@
+use uuid::Uuid;
+
+use crate::document::DocumentId;
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, derive_more::Display, derive_more::Into)]
+pub struct ViewId(Uuid);
+
+impl ViewId {
+    pub(crate) fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+    pub(crate) fn gen() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+// TODO this will need to also account for variable-width fonts, ligatures as well as tab characters in the future.
+
+/// A view represents a part of a [Buffer] that is shown by a client.
+/// It stores information about the viewport in terms of lines and columns,
+/// and thus currently assumes a monospaced font.
+pub struct View {
+    /// Index of the first line shown in the viewport
+    pub first_visible_line: usize,
+    /// Index of the first column shown in the viewport
+    pub first_visible_col: usize,
+    /// Number of lines shown in the viewport
+    pub height: usize,
+    /// Number of columns shown in the viewport
+    pub width: usize,
+    /// Id of the [Document] this view looks into
+    pub document_id: DocumentId,
+}
+
+impl View {
+    pub fn new(document_id: DocumentId, height: usize, width: usize) -> Self {
+        Self {
+            first_visible_line: 0,
+            first_visible_col: 0,
+            height,
+            width,
+            document_id,
+        }
+    }
+
+    /// first and last line shown in the viewport
+    pub fn displayed_lines(&self) -> (usize, usize) {
+        (
+            self.first_visible_line,
+            self.first_visible_line + self.height,
+        )
+    }
+
+    /// first and last column shown in the viewport
+    pub fn displayed_cols(&self) -> (usize, usize) {
+        (self.first_visible_col, self.first_visible_col + self.width)
+    }
+}

--- a/crates/bazed-core/src/view.rs
+++ b/crates/bazed-core/src/view.rs
@@ -21,9 +21,9 @@ impl ViewId {
 /// and thus currently assumes a monospaced font.
 pub struct View {
     /// Index of the first line shown in the viewport
-    pub first_visible_line: usize,
+    pub first_line: usize,
     /// Index of the first column shown in the viewport
-    pub first_visible_col: usize,
+    pub first_col: usize,
     /// Number of lines shown in the viewport
     pub height: usize,
     /// Number of columns shown in the viewport
@@ -35,8 +35,8 @@ pub struct View {
 impl View {
     pub fn new(document_id: DocumentId, height: usize, width: usize) -> Self {
         Self {
-            first_visible_line: 0,
-            first_visible_col: 0,
+            first_line: 0,
+            first_col: 0,
             height,
             width,
             document_id,
@@ -44,15 +44,12 @@ impl View {
     }
 
     /// first and last line shown in the viewport
-    pub fn displayed_lines(&self) -> (usize, usize) {
-        (
-            self.first_visible_line,
-            self.first_visible_line + self.height,
-        )
+    pub fn last_line(&self) -> usize {
+        self.first_line + self.height
     }
 
     /// first and last column shown in the viewport
-    pub fn displayed_cols(&self) -> (usize, usize) {
-        (self.first_visible_col, self.first_visible_col + self.width)
+    pub fn last_col(&self) -> usize {
+        self.first_col + self.width
     }
 }

--- a/crates/bazed-rpc/src/core_proto.rs
+++ b/crates/bazed-rpc/src/core_proto.rs
@@ -5,6 +5,11 @@ use uuid::Uuid;
 
 use crate::keycode::KeyInput;
 
+/// Id of a request, which is any RPC invocation that expects a response.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RequestId(pub Uuid);
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CaretPosition {
@@ -15,21 +20,41 @@ pub struct CaretPosition {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "method", content = "params")]
 pub enum ToFrontend {
-    Open {
-        id: Uuid,
+    OpenDocument {
+        document_id: Uuid,
         path: Option<PathBuf>,
         text: String,
     },
     UpdateDocument {
-        id: Uuid,
+        document_id: Uuid,
         text: String,
         carets: Vec<CaretPosition>,
+    },
+
+    ViewOpenedResponse {
+        request_id: RequestId,
+        view_id: Uuid,
     },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "method", content = "params")]
 pub enum ToBackend {
-    KeyPressed(KeyInput),
-    MouseInput(CaretPosition),
+    KeyPressed {
+        view_id: Uuid,
+        input: KeyInput,
+    },
+
+    /// Mouse was clicked. The coordinates are absolute.
+    MouseInput {
+        view_id: Uuid,
+        position: CaretPosition,
+    },
+
+    ViewOpened {
+        request_id: RequestId,
+        document_id: Uuid,
+        height: usize,
+        width: usize,
+    },
 }

--- a/crates/bazed-rpc/src/core_proto.rs
+++ b/crates/bazed-rpc/src/core_proto.rs
@@ -25,12 +25,17 @@ pub enum ToFrontend {
         path: Option<PathBuf>,
         text: String,
     },
-    UpdateDocument {
-        document_id: Uuid,
-        text: String,
+    /// Sent whenever anything in the view changed, i.e. the content,
+    /// the viewport, or a caret position
+    UpdateView {
+        view_id: Uuid,
+        first_line: usize,
+        height: usize,
+        text: Vec<String>,
+        /// caret positions are absolute
         carets: Vec<CaretPosition>,
     },
-
+    /// Response to the [ToBackend::ViewOpened] request
     ViewOpenedResponse {
         request_id: RequestId,
         view_id: Uuid,
@@ -44,13 +49,20 @@ pub enum ToBackend {
         view_id: Uuid,
         input: KeyInput,
     },
-
     /// Mouse was clicked. The coordinates are absolute.
     MouseInput {
         view_id: Uuid,
         position: CaretPosition,
     },
-
+    /// Send when the viewport for a given view has changed,
+    /// i.e. because the window was resized or the user scrolled.
+    ViewportChanged {
+        view_id: Uuid,
+        height: usize,
+        width: usize,
+        first_line: usize,
+        first_col: usize,
+    },
     ViewOpened {
         request_id: RequestId,
         document_id: Uuid,

--- a/crates/bazed-rpc/src/server.rs
+++ b/crates/bazed-rpc/src/server.rs
@@ -11,12 +11,9 @@ pub struct ClientSendHandle(
 
 impl ClientSendHandle {
     #[tracing::instrument(skip(self))]
-    pub async fn send_rpc_notification(
-        &mut self,
-        notification: ToFrontend,
-    ) -> Result<(), tungstenite::Error> {
-        tracing::debug!("Sending rpc notification to client: {notification:?}");
-        let json = serde_json::to_string(&notification).unwrap();
+    pub async fn send_rpc(&mut self, call: ToFrontend) -> Result<(), tungstenite::Error> {
+        tracing::debug!("Sending rpc call to client: {call:?}");
+        let json = serde_json::to_string(&call).unwrap();
         self.0.send(tungstenite::Message::Text(json)).await
     }
 }


### PR DESCRIPTION
Views represent, what a frontend sees of a document. This PR adds the related types and RPC api, as well as sending viewport update events when scrolling off the screen.

This depends on #23 