### PR TITLE
feat(core): Add Ctrl+S save mapping, atomically write files

### DIFF
--- a/crates/bazed-core/src/buffer.rs
+++ b/crates/bazed-core/src/buffer.rs
@@ -6,7 +6,7 @@ use xi_rope::{engine::Engine, tree::NodeInfo, DeltaBuilder, Rope, RopeDelta, Tra
 
 use crate::{
     mark::{Mark, MarkId},
-    user_buffer_op::{BufferOp, EditOp, MovementOp},
+    user_buffer_op::{EditOp, MovementOp},
 };
 
 /// Stores all the active marks in a buffer.
@@ -15,6 +15,7 @@ use crate::{
 /// - *Mark* refers to any marked position in the buffer
 /// - *Caret* refers to marks that represent concrete, user-controlled carets.
 ///   (i.e.: The places where text gets inserted)
+#[derive(Debug)]
 struct BufferMarks {
     marks: HashMap<MarkId, Mark>,
     /// All the active carets. There will always be at least one.
@@ -68,6 +69,7 @@ impl BufferMarks {
     }
 }
 
+#[derive(Debug)]
 pub struct Buffer {
     text: Rope,
     engine: Engine,
@@ -91,6 +93,11 @@ impl Buffer {
 
     pub fn content_to_string(&self) -> String {
         self.engine.get_head().to_string()
+    }
+
+    /// Return a snapshot of the latest commited state of the text
+    pub fn head_rope(&self) -> &Rope {
+        self.engine.get_head()
     }
 
     pub fn all_carets(&self) -> NonEmpty<Position> {
@@ -167,13 +174,6 @@ impl Buffer {
             self.undo_group_id -= 1;
             self.engine.undo(undos);
             self.text = self.engine.get_head().clone();
-        }
-    }
-
-    pub(crate) fn apply_buffer_op(&mut self, op: BufferOp) {
-        match op {
-            BufferOp::Edit(x) => self.apply_edit_op(x),
-            BufferOp::Movement(x) => self.apply_movement_op(x),
         }
     }
 

--- a/crates/bazed-core/src/input_mapper.rs
+++ b/crates/bazed-core/src/input_mapper.rs
@@ -2,30 +2,31 @@
 
 use bazed_rpc::keycode::{Key, KeyInput};
 
-use crate::user_buffer_op::{BufferOp, EditOp, MovementOp};
+use crate::user_buffer_op::{DocumentOp, EditOp, MovementOp, Operation};
 
-pub(crate) fn interpret_key_input(input: &KeyInput) -> Option<BufferOp> {
+pub(crate) fn interpret_key_input(input: &KeyInput) -> Option<Operation> {
     if input.ctrl_held() {
         match input.key {
-            Key::Char('z') => Some(BufferOp::Edit(EditOp::Undo)),
+            Key::Char('z') => Some(Operation::Edit(EditOp::Undo)),
+            Key::Char('s') => Some(Operation::Document(DocumentOp::Save)),
             _ => None,
         }
     } else {
         // for now we just ignore the fact that other modifiers like Alt and Win exist.
         match input.key {
-            Key::Char(c) if input.shift_held() => Some(BufferOp::Edit(EditOp::Insert(
+            Key::Char(c) if input.shift_held() => Some(Operation::Edit(EditOp::Insert(
                 c.to_ascii_lowercase().to_string(),
             ))),
-            Key::Char(c) => Some(BufferOp::Edit(EditOp::Insert(c.to_string()))),
-            Key::Backspace => Some(BufferOp::Edit(EditOp::Backspace)),
+            Key::Char(c) => Some(Operation::Edit(EditOp::Insert(c.to_string()))),
+            Key::Backspace => Some(Operation::Edit(EditOp::Backspace)),
             // TODO we'll probably need to special-case this
-            Key::Return => Some(BufferOp::Edit(EditOp::Insert("\n".to_string()))),
+            Key::Return => Some(Operation::Edit(EditOp::Insert("\n".to_string()))),
             // TODO we'll _definitely_ need to special case this for soft tabs
-            Key::Tab => Some(BufferOp::Edit(EditOp::Insert("\t".to_string()))),
-            Key::Left => Some(BufferOp::Movement(MovementOp::Left)),
-            Key::Right => Some(BufferOp::Movement(MovementOp::Right)),
-            Key::Up => Some(BufferOp::Movement(MovementOp::Up)),
-            Key::Down => Some(BufferOp::Movement(MovementOp::Down)),
+            Key::Tab => Some(Operation::Edit(EditOp::Insert("\t".to_string()))),
+            Key::Left => Some(Operation::Movement(MovementOp::Left)),
+            Key::Right => Some(Operation::Movement(MovementOp::Right)),
+            Key::Up => Some(Operation::Movement(MovementOp::Up)),
+            Key::Down => Some(Operation::Movement(MovementOp::Down)),
             _ => None,
         }
     }

--- a/crates/bazed-core/src/user_buffer_op.rs
+++ b/crates/bazed-core/src/user_buffer_op.rs
@@ -3,9 +3,15 @@
 //! These will occur at the caret positions, and are thus only used for directly userfacing operations
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum BufferOp {
+pub(crate) enum Operation {
+    Document(DocumentOp),
     Edit(EditOp),
     Movement(MovementOp),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) enum DocumentOp {
+    Save,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
This PR adds a mapping for Ctrl+S to save files.
It also makes writing files atomic, by first writing to a swp file.
