### PR TITLE
feat(core): Add high-level movement operations

### DIFF
--- a/crates/bazed-core/src/app.rs
+++ b/crates/bazed-core/src/app.rs
@@ -173,7 +173,7 @@ impl App {
                 DocumentOp::Save => document.write_to_file().await?,
             },
             Operation::Edit(op) => document.buffer.apply_edit_op(op),
-            Operation::Movement(op) => document.buffer.apply_movement_op(op),
+            Operation::Movement(op) => document.buffer.apply_movement_op(view, op),
         }
         self.event_send
             .send_rpc(document.create_update_notification(view_id, view))

--- a/crates/bazed-core/src/document.rs
+++ b/crates/bazed-core/src/document.rs
@@ -67,15 +67,15 @@ impl Document {
     pub fn create_update_notification(&self, view_id: ViewId, view: &View) -> ToFrontend {
         let lines = self
             .buffer
-            .lines_between(view.first_line, view.last_line())
+            .lines_between(view.vp.first_line, view.vp.last_line())
             .into_iter()
             .map(|x| x.to_string())
             .collect::<Vec<_>>();
 
         ToFrontend::UpdateView {
             view_id: view_id.into(),
-            first_line: view.first_line,
-            height: view.height,
+            first_line: view.vp.first_line,
+            height: view.vp.height,
             text: lines,
             carets: self
                 .buffer

--- a/crates/bazed-core/src/user_buffer_op.rs
+++ b/crates/bazed-core/src/user_buffer_op.rs
@@ -21,10 +21,16 @@ pub(crate) enum EditOp {
     Undo,
 }
 
+// currently just used in tests
+#[allow(unused)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum MovementOp {
     Left,
     Right,
     Up,
     Down,
+    StartOfLine,
+    EndOfLine,
+    TopOfViewport,
+    BottomOfViewport,
 }

--- a/crates/bazed-core/src/view.rs
+++ b/crates/bazed-core/src/view.rs
@@ -17,39 +17,46 @@ impl ViewId {
 // TODO this will need to also account for variable-width fonts, ligatures as well as tab characters in the future.
 
 /// A view represents a part of a [Buffer] that is shown by a client.
-/// It stores information about the viewport in terms of lines and columns,
-/// and thus currently assumes a monospaced font.
 pub struct View {
-    /// Index of the first line shown in the viewport
-    pub first_line: usize,
-    /// Index of the first column shown in the viewport
-    pub first_col: usize,
-    /// Number of lines shown in the viewport
-    pub height: usize,
-    /// Number of columns shown in the viewport
-    pub width: usize,
     /// Id of the [Document] this view looks into
     pub document_id: DocumentId,
+    /// Viewport of this view
+    pub vp: Viewport,
 }
 
 impl View {
-    pub fn new(document_id: DocumentId, height: usize, width: usize) -> Self {
+    pub fn new(document_id: DocumentId, viewport: Viewport) -> Self {
         Self {
-            first_line: 0,
-            first_col: 0,
-            height,
-            width,
             document_id,
+            vp: viewport,
         }
     }
+}
 
+/// Information about which part of a [Buffer] is visible to the client.
+/// Currently only vertical position and height is considered.
+pub struct Viewport {
+    /// Index of the first line shown in the viewport
+    pub first_line: usize,
+    /// Number of lines shown in the viewport
+    pub height: usize,
+}
+
+impl Viewport {
+    pub fn new(first_line: usize, height: usize) -> Self {
+        Self { first_line, height }
+    }
+
+    /// Create a viewport starting at line 0 and going down 100 million lines.
+    #[cfg(test)]
+    pub fn new_ginormeous() -> Self {
+        Self {
+            first_line: 0,
+            height: 100_000_000,
+        }
+    }
     /// first and last line shown in the viewport
     pub fn last_line(&self) -> usize {
         self.first_line + self.height
-    }
-
-    /// first and last column shown in the viewport
-    pub fn last_col(&self) -> usize {
-        self.first_col + self.width
     }
 }

--- a/crates/bazed-rpc/src/core_proto.rs
+++ b/crates/bazed-rpc/src/core_proto.rs
@@ -62,14 +62,11 @@ pub enum ToBackend {
     ViewportChanged {
         view_id: Uuid,
         height: usize,
-        width: usize,
         first_line: usize,
-        first_col: usize,
     },
     ViewOpened {
         request_id: RequestId,
         document_id: Uuid,
         height: usize,
-        width: usize,
     },
 }


### PR DESCRIPTION
This PR adds a few high-level movement operations, such as 
- Moving to the start and end of a line
- Moving to the bottom and top of the viewport
