### PR TITLE
feat(core): Add delete key, generalize Buffers deletion functionality

### DIFF
--- a/crates/bazed-core/src/input_mapper.rs
+++ b/crates/bazed-core/src/input_mapper.rs
@@ -2,7 +2,7 @@
 
 use bazed_rpc::keycode::{Key, KeyInput};
 
-use crate::user_buffer_op::{BufferOp, DocumentOp, Motion, Operation};
+use crate::user_buffer_op::{BufferOp, DocumentOp, Motion, Operation, Trajectory};
 
 pub(crate) fn interpret_key_input(input: &KeyInput) -> Option<Operation> {
     if input.ctrl_held() {
@@ -20,7 +20,8 @@ pub(crate) fn interpret_key_input(input: &KeyInput) -> Option<Operation> {
                 Buffer(BufferOp::Insert(c.to_ascii_lowercase().to_string()))
             },
             Key::Char(c) => Buffer(BufferOp::Insert(c.to_string())),
-            Key::Backspace => Buffer(BufferOp::Backspace),
+            Key::Backspace => Buffer(BufferOp::Delete(Trajectory::Backwards)),
+            Key::Delete => Buffer(BufferOp::Delete(Trajectory::Forwards)),
             // TODO we'll probably need to special-case this
             Key::Return => Buffer(BufferOp::Insert("\n".to_string())),
             // TODO we'll _definitely_ need to special case this for soft tabs

--- a/crates/bazed-core/src/user_buffer_op.rs
+++ b/crates/bazed-core/src/user_buffer_op.rs
@@ -2,6 +2,12 @@
 //! This includes edit and movement operations.
 //! These will occur at the caret positions, and are thus only used for directly userfacing operations
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum Trajectory {
+    Forwards,
+    Backwards,
+}
+
 /// Category of an edit, used for grouping operations into undo-groups
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum EditType {
@@ -25,7 +31,7 @@ pub(crate) enum DocumentOp {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) enum BufferOp {
     Insert(String),
-    Backspace,
+    Delete(Trajectory),
     Undo,
     Redo,
     Move(Motion),


### PR DESCRIPTION
This PR generalizes the delete functionality in Buffer and uses it to add delete forwards (via `Key::Delete`)
