### PR TITLE
refactor(core) use lapce-xi-rope over xi-rope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ dependencies = [
  "color-eyre",
  "derive_more",
  "futures",
+ "lapce-xi-rope",
  "maplit",
  "nonempty",
  "tap",
@@ -81,7 +82,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "xi-rope",
 ]
 
 [[package]]
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.5.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0fdd54b507df8f22012890aadd099979befdba27713c767993f8380112ca7c"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "byteorder"
@@ -368,6 +368,18 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "lapce-xi-rope"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ae23edb8cf91f01edd9a87c88623eae3977c8d647a31c57cb12f1a125ca10a"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "regex",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1012,15 +1024,3 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
-
-[[package]]
-name = "xi-rope"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1266c6612194a86462905372bc7bbc9887e3f3826da6b82ea4a35492bc65d5a"
-dependencies = [
- "bytecount",
- "memchr",
- "regex",
- "unicode-segmentation",
-]

--- a/crates/bazed-core/Cargo.toml
+++ b/crates/bazed-core/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-xi-rope = "0.3.0"
+xi-rope = { package = "lapce-xi-rope", version = "0.3.1" }
 nonempty = "0.8.1"
 color-eyre.workspace = true
 uuid.workspace = true


### PR DESCRIPTION
Still gets maintained, seems to have a few performance improvements.

Acked-by: ElKowar
Signed-off-by: buffet <niclas@countingsort.com>
