### PR TITLE
all movements can select

### DIFF
--- a/crates/bazed-rpc/src/keycode.rs
+++ b/crates/bazed-rpc/src/keycode.rs
@@ -13,7 +13,6 @@ impl KeyInput {
     pub fn shift_held(&self) -> bool {
         self.modifiers.contains(&Modifier::Shift)
     }
-
     pub fn ctrl_held(&self) -> bool {
         self.modifiers.contains(&Modifier::Ctrl)
     }


### PR DESCRIPTION
This PR makes all movement keys able to also do selection operations instead, when shift is held
