### PR TITLE
Implement word boundary search and wordwise movement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-general-category",
  "uuid",
 ]
 
@@ -879,6 +880,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/bazed-core/Cargo.toml
+++ b/crates/bazed-core/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 
 [dependencies]
 xi-rope = { package = "lapce-xi-rope", version = "0.3.1" }
+unicode-general-category = "0.6.0"
 nonempty = "0.8.1"
 color-eyre.workspace = true
 uuid.workspace = true

--- a/crates/bazed-core/src/input_mapper.rs
+++ b/crates/bazed-core/src/input_mapper.rs
@@ -2,43 +2,42 @@
 
 use bazed_rpc::keycode::{Key, KeyInput};
 
-use crate::user_buffer_op::{BufferOp, DocumentOp, Motion, Operation, Trajectory};
+use crate::{
+    user_buffer_op::{BufferOp, DocumentOp, Motion, Operation, Trajectory},
+    word_boundary::WordBoundaryType,
+};
 
 pub(crate) fn interpret_key_input(input: &KeyInput) -> Option<Operation> {
-    if input.ctrl_held() {
-        match input.key {
-            Key::Char('z') => Some(Operation::Buffer(BufferOp::Undo)),
-            Key::Char('y') => Some(Operation::Buffer(BufferOp::Redo)),
-            Key::Char('s') => Some(Operation::Document(DocumentOp::Save)),
-            _ => None,
-        }
-    } else {
-        use Operation::*;
+    Some(match input.key {
+        Key::Char(c) if input.ctrl_held() => match c {
+            'z' => Operation::Buffer(BufferOp::Undo),
+            'y' => Operation::Buffer(BufferOp::Redo),
+            's' => Operation::Document(DocumentOp::Save),
+            _ => return None,
+        },
+        Key::Char(c) if input.shift_held() => {
+            Operation::Buffer(BufferOp::Insert(c.to_ascii_lowercase().to_string()))
+        },
+        Key::Char(c) => Operation::Buffer(BufferOp::Insert(c.to_string())),
+        Key::Backspace => Operation::Buffer(BufferOp::Delete(Trajectory::Backwards)),
+        Key::Delete => Operation::Buffer(BufferOp::Delete(Trajectory::Forwards)),
+        Key::Return => Operation::Buffer(BufferOp::Insert("\n".to_string())),
+        Key::Tab => Operation::Buffer(BufferOp::Insert("\t".to_string())),
 
-        // for now we just ignore the fact that other modifiers like Alt and Win exist.
-        Some(match input.key {
-            Key::Char(c) if input.shift_held() => {
-                Buffer(BufferOp::Insert(c.to_ascii_lowercase().to_string()))
-            },
-            Key::Char(c) => Buffer(BufferOp::Insert(c.to_string())),
-            Key::Backspace => Buffer(BufferOp::Delete(Trajectory::Backwards)),
-            Key::Delete => Buffer(BufferOp::Delete(Trajectory::Forwards)),
-            Key::Return => Buffer(BufferOp::Insert("\n".to_string())),
-            Key::Tab => Buffer(BufferOp::Insert("\t".to_string())),
-
-            _ => match key_to_motion(&input.key) {
-                Some(motion) if input.shift_held() => Buffer(BufferOp::Selection(motion)),
-                Some(motion) if input.modifiers.is_empty() => Buffer(BufferOp::Move(motion)),
-                _ => return None,
-            },
-        })
-    }
+        _ => match key_to_motion(input.ctrl_held(), &input.key) {
+            Some(motion) if input.shift_held() => Operation::Buffer(BufferOp::Selection(motion)),
+            Some(motion) => Operation::Buffer(BufferOp::Move(motion)),
+            _ => return None,
+        },
+    })
 }
 
 /// Map a movement key into the corresponding [Motion].
 /// This most likely won't scale to our future architecture, but it works for now
-fn key_to_motion(key: &Key) -> Option<Motion> {
+fn key_to_motion(ctrl_held: bool, key: &Key) -> Option<Motion> {
     match key {
+        Key::Right if ctrl_held => Some(Motion::NextWordBoundary(WordBoundaryType::Start)),
+
         Key::Left => Some(Motion::Left),
         Key::Right => Some(Motion::Right),
         Key::Up => Some(Motion::Up),

--- a/crates/bazed-core/src/input_mapper.rs
+++ b/crates/bazed-core/src/input_mapper.rs
@@ -37,6 +37,7 @@ pub(crate) fn interpret_key_input(input: &KeyInput) -> Option<Operation> {
 fn key_to_motion(ctrl_held: bool, key: &Key) -> Option<Motion> {
     match key {
         Key::Right if ctrl_held => Some(Motion::NextWordBoundary(WordBoundaryType::Start)),
+        Key::Left if ctrl_held => Some(Motion::PrevWordBoundary(WordBoundaryType::Start)),
 
         Key::Left => Some(Motion::Left),
         Key::Right => Some(Motion::Right),

--- a/crates/bazed-core/src/lib.rs
+++ b/crates/bazed-core/src/lib.rs
@@ -7,6 +7,7 @@ mod input_mapper;
 pub mod region;
 mod user_buffer_op;
 pub mod view;
+mod word_boundary;
 
 #[cfg(test)]
 mod test_util;

--- a/crates/bazed-core/src/user_buffer_op.rs
+++ b/crates/bazed-core/src/user_buffer_op.rs
@@ -2,6 +2,8 @@
 //! This includes edit and movement operations.
 //! These will occur at the caret positions, and are thus only used for directly userfacing operations
 
+use crate::word_boundary::WordBoundaryType;
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum Trajectory {
     Forwards,
@@ -52,4 +54,5 @@ pub(crate) enum Motion {
     EndOfLine,
     TopOfViewport,
     BottomOfViewport,
+    NextWordBoundary(WordBoundaryType),
 }

--- a/crates/bazed-core/src/user_buffer_op.rs
+++ b/crates/bazed-core/src/user_buffer_op.rs
@@ -55,4 +55,5 @@ pub(crate) enum Motion {
     TopOfViewport,
     BottomOfViewport,
     NextWordBoundary(WordBoundaryType),
+    PrevWordBoundary(WordBoundaryType),
 }

--- a/crates/bazed-core/src/word_boundary.rs
+++ b/crates/bazed-core/src/word_boundary.rs
@@ -1,0 +1,167 @@
+use unicode_general_category::GeneralCategory;
+use xi_rope::Rope;
+
+/// Type of a word-boundary.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum WordBoundaryType {
+    /// Indicates the start of a "word"
+    Start,
+    /// Indicates the end of a "word"
+    End,
+    /// Indicates that the position is both a start and an end,
+    /// i.e. in the case of `a__`, at offset 1, as the underscores
+    /// are also grouped into one word.
+    Both,
+}
+
+impl WordBoundaryType {
+    pub(crate) fn between_types(a: CharCategory, b: CharCategory) -> Option<WordBoundaryType> {
+        use CharCategory::*;
+        use WordBoundaryType::*;
+        match (a, b) {
+            (Word, Word)
+            | (Punctuation, Punctuation)
+            | (Whitespace, Whitespace)
+            | (Other, _)
+            | (_, Other) => None,
+
+            (Word, Punctuation) | (Punctuation, Word) => Some(Both),
+            (Whitespace, Word) => Some(Start),
+            (Word, Whitespace) => Some(End),
+            (Whitespace, Punctuation) => Some(Start),
+            (Punctuation, Whitespace) => Some(End),
+        }
+    }
+    pub(crate) fn between(a: char, b: char) -> Option<WordBoundaryType> {
+        Self::between_types(CharCategory::of_char(a), CharCategory::of_char(b))
+    }
+}
+
+/// Category of character, loosely derived from the unicode general category defined
+/// in [Unicode Standard Annex #44, Section 5.7.1](http://www.unicode.org/reports/tr44/#General_Category_Values)
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CharCategory {
+    /// Any whitespace or lineseparator character
+    Whitespace,
+    /// Any word character.
+    /// In the future, it should be possible to configure if characters like `_` or `-` count as word-characters or not.
+    Word,
+    /// Any punctuation character.
+    Punctuation,
+    /// Any character that doesn't fit any other category.
+    /// This also includes format control characters, UTF-16 surrogate code points.
+    Other,
+}
+
+impl CharCategory {
+    fn of_char(c: char) -> Self {
+        if c.is_whitespace() {
+            return Self::Whitespace;
+        }
+
+        use GeneralCategory::*;
+        match unicode_general_category::get_general_category(c) {
+            OtherPunctuation | OpenPunctuation | ClosePunctuation | InitialPunctuation
+            | FinalPunctuation | ConnectorPunctuation | DashPunctuation | MathSymbol
+            | CurrencySymbol | ModifierSymbol => Self::Punctuation,
+
+            LineSeparator | ParagraphSeparator | SpaceSeparator => Self::Whitespace,
+
+            LowercaseLetter | TitlecaseLetter | UppercaseLetter | ModifierLetter | OtherLetter
+            | OtherNumber | LetterNumber | DecimalNumber | OtherSymbol => Self::Word,
+
+            Control | Format | Surrogate | Unassigned | PrivateUse | SpacingMark
+            | NonspacingMark | EnclosingMark => Self::Other,
+        }
+    }
+}
+
+/// Boundaries are always between chars:
+/// in `"foo bar"`, there is an `End`-boundary at index 3 (`"foo| bar"`),
+/// as well as a `Start`-boundary at index 4 (`"foo |bar"`).
+/// Thus: An `End`-boundary at index N really means the character at index (N-1) is in a word, and at index N is not.
+///
+/// This iterator will always emit an `End`-boundary at the end of the text.
+/// Thus, this is guaranteed to always at least yield one value.
+pub(crate) struct WordBoundaries<I> {
+    iter: I,
+    prev: Option<char>,
+    /// The index of the cursor. `prev` is to the left of this (effectively at `current_offset - 1`)
+    current_offset: usize,
+    /// true if the iterator has been exhausted and final `End` has already been yielded
+    done: bool,
+}
+impl<I: Iterator<Item = char>> WordBoundaries<I> {
+    /// Offsets are added to the initial offset
+    pub(crate) fn from_iter<It: IntoIterator<IntoIter = I>>(
+        iter: It,
+        initial_offset: usize,
+    ) -> Self {
+        Self {
+            iter: iter.into_iter(),
+            prev: None,
+            done: false,
+            current_offset: initial_offset,
+        }
+    }
+}
+
+impl<I: Iterator<Item = char>> Iterator for WordBoundaries<I> {
+    type Item = (usize, WordBoundaryType);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        loop {
+            self.current_offset += 1;
+            let Some(cur) = self.iter.next() else {
+                self.done = true;
+                return Some((self.current_offset - 1, WordBoundaryType::End));
+            };
+            let prev = self.prev;
+            self.prev = Some(cur);
+            if let Some(prev) = prev {
+                if let Some(boundary) = WordBoundaryType::between(prev, cur) {
+                    return Some((self.current_offset - 1, boundary));
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn find_word_boundaries(
+    rope: &Rope,
+    start_at: usize,
+) -> impl Iterator<Item = (usize, WordBoundaryType)> + '_ {
+    WordBoundaries::from_iter(
+        rope.iter_chunks(start_at..).flat_map(|c| c.chars()),
+        start_at,
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::WordBoundaries;
+    use crate::{test_util, word_boundary::WordBoundaryType};
+
+    fn boundaries(s: &str) -> Vec<(usize, WordBoundaryType)> {
+        WordBoundaries::from_iter(s.chars(), 0).collect()
+    }
+
+    #[test]
+    fn test_word_boundaries() {
+        test_util::setup_test();
+        use WordBoundaryType::*;
+        let actual = boundaries("foo foo...");
+        assert_eq!(vec![(3, End), (4, Start), (7, Both), (10, End)], actual);
+        let actual = boundaries(" foo ");
+        assert_eq!(vec![(1, Start), (4, End), (5, End)], actual);
+
+        // TODO we should have configurable word separators to allow `_` to not break words if the users wants that
+        let actual = boundaries("foo_bar");
+        assert_eq!(vec![(3, Both), (4, Both), (7, End)], actual);
+        let actual = boundaries("foo___");
+        assert_eq!(vec![(3, Both), (6, End)], actual);
+    }
+}

--- a/crates/bazed-core/src/word_boundary.rs
+++ b/crates/bazed-core/src/word_boundary.rs
@@ -1,5 +1,36 @@
+//! Traverse a text, looking for word boundaries.
+
 use unicode_general_category::GeneralCategory;
-use xi_rope::Rope;
+use xi_rope::{interval::IntervalBounds, Cursor, Interval, Rope, RopeInfo};
+
+/// Search forwards for any word boundaries in a rope, starting at a given offset.
+/// Note that the location at the offset itself is not considered.
+///
+/// Will always yield a [WordBoundaryType::Both] at the end of the text.
+pub(crate) fn find_word_boundaries(
+    rope: &Rope,
+    start_at: usize,
+) -> impl Iterator<Item = (usize, WordBoundaryType)> + '_ {
+    WordBoundaries::from_iter(false, rope.iter_chunks(start_at..).flat_map(|c| c.chars()))
+        .map(move |(offset, t)| (offset + start_at, t))
+        .chain(std::iter::once((rope.len(), WordBoundaryType::Both)))
+}
+
+/// Search backwards for any word boundaries in a rope, starting at a given offset.
+/// Note that the location at the offset itself is not considered.
+///
+/// Will always yield a [WordBoundaryType::Both] at the start of the text.
+pub(crate) fn find_word_boundaries_backwards(
+    rope: &Rope,
+    start_at: usize,
+) -> impl Iterator<Item = (usize, WordBoundaryType)> + '_ {
+    WordBoundaries::from_iter(
+        true,
+        iter_rope_chunks_reverse(rope, ..start_at).flat_map(|c| c.chars().rev()),
+    )
+    .map(move |(offset, t)| (start_at.saturating_sub(offset), t))
+    .chain(std::iter::once((0, WordBoundaryType::Both)))
+}
 
 /// Type of a word-boundary.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -34,6 +65,12 @@ impl WordBoundaryType {
     }
     pub(crate) fn between(a: char, b: char) -> Option<WordBoundaryType> {
         Self::between_types(CharCategory::of_char(a), CharCategory::of_char(b))
+    }
+
+    /// Compare two word boundaries, checking if they match.
+    /// If either boundary is `Other` this will always match
+    pub(crate) fn matches(&self, other: &Self) -> bool {
+        self == &Self::Both || other == &Self::Both || self == other
     }
 }
 
@@ -81,27 +118,22 @@ impl CharCategory {
 /// as well as a `Start`-boundary at index 4 (`"foo |bar"`).
 /// Thus: An `End`-boundary at index N really means the character at index (N-1) is in a word, and at index N is not.
 ///
-/// This iterator will always emit an `End`-boundary at the end of the text.
-/// Thus, this is guaranteed to always at least yield one value.
+/// This iterator will not emit an `End`-boundary at the end of the text.
 pub(crate) struct WordBoundaries<I> {
     iter: I,
     prev: Option<char>,
     /// The index of the cursor. `prev` is to the left of this (effectively at `current_offset - 1`)
     current_offset: usize,
-    /// true if the iterator has been exhausted and final `End` has already been yielded
-    done: bool,
+    /// when true, the previous character and current character will be swapped in boundary checks
+    reversing: bool,
 }
 impl<I: Iterator<Item = char>> WordBoundaries<I> {
-    /// Offsets are added to the initial offset
-    pub(crate) fn from_iter<It: IntoIterator<IntoIter = I>>(
-        iter: It,
-        initial_offset: usize,
-    ) -> Self {
+    pub(crate) fn from_iter<It: IntoIterator<IntoIter = I>>(reversing: bool, iter: It) -> Self {
         Self {
             iter: iter.into_iter(),
             prev: None,
-            done: false,
-            current_offset: initial_offset,
+            current_offset: 0,
+            reversing,
         }
     }
 }
@@ -110,19 +142,18 @@ impl<I: Iterator<Item = char>> Iterator for WordBoundaries<I> {
     type Item = (usize, WordBoundaryType);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
         loop {
             self.current_offset += 1;
-            let Some(cur) = self.iter.next() else {
-                self.done = true;
-                return Some((self.current_offset - 1, WordBoundaryType::End));
-            };
+            let cur = self.iter.next()?;
             let prev = self.prev;
             self.prev = Some(cur);
             if let Some(prev) = prev {
-                if let Some(boundary) = WordBoundaryType::between(prev, cur) {
+                let boundary = if self.reversing {
+                    WordBoundaryType::between(cur, prev)
+                } else {
+                    WordBoundaryType::between(prev, cur)
+                };
+                if let Some(boundary) = boundary {
                     return Some((self.current_offset - 1, boundary));
                 }
             }
@@ -130,38 +161,89 @@ impl<I: Iterator<Item = char>> Iterator for WordBoundaries<I> {
     }
 }
 
-pub(crate) fn find_word_boundaries(
-    rope: &Rope,
-    start_at: usize,
-) -> impl Iterator<Item = (usize, WordBoundaryType)> + '_ {
-    WordBoundaries::from_iter(
-        rope.iter_chunks(start_at..).flat_map(|c| c.chars()),
-        start_at,
-    )
+/// Returns an iterator that reverses over chunks of the rope.
+fn iter_rope_chunks_reverse<T: IntervalBounds>(rope: &Rope, range: T) -> ReverseChunkIter {
+    let Interval { start, end } = range.into_interval(rope.len());
+    ReverseChunkIter {
+        cursor: Cursor::new(rope, end),
+        cursor_at_end: true,
+        min: start,
+    }
+}
+
+/// More or less a copy of [xi_rope::rope::ChunkIter], but traversing the rope in reverse order
+struct ReverseChunkIter<'a> {
+    cursor: Cursor<'a, RopeInfo>,
+    cursor_at_end: bool,
+    min: usize,
+}
+
+impl<'a> Iterator for ReverseChunkIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        if self.cursor.pos() < self.min {
+            return None;
+        }
+        let (leaf, offset_within_leaf) = self.cursor.get_leaf()?;
+        let start_offset_of_leaf = self.cursor.pos() - offset_within_leaf;
+        let start_pos = self.min.saturating_sub(start_offset_of_leaf);
+        self.cursor.prev_leaf();
+        if self.cursor_at_end {
+            self.cursor_at_end = false;
+            Some(&leaf[start_pos..offset_within_leaf])
+        } else {
+            Some(&leaf[start_pos..])
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use super::WordBoundaries;
-    use crate::{test_util, word_boundary::WordBoundaryType};
+    use xi_rope::Rope;
 
-    fn boundaries(s: &str) -> Vec<(usize, WordBoundaryType)> {
-        WordBoundaries::from_iter(s.chars(), 0).collect()
-    }
+    use super::WordBoundaries;
+    use crate::{
+        test_util,
+        word_boundary::{find_word_boundaries, find_word_boundaries_backwards, WordBoundaryType},
+    };
 
     #[test]
     fn test_word_boundaries() {
         test_util::setup_test();
         use WordBoundaryType::*;
+        fn boundaries(s: &str) -> Vec<(usize, WordBoundaryType)> {
+            WordBoundaries::from_iter(false, s.chars()).collect()
+        }
         let actual = boundaries("foo foo...");
-        assert_eq!(vec![(3, End), (4, Start), (7, Both), (10, End)], actual);
+        assert_eq!(vec![(3, End), (4, Start), (7, Both)], actual);
         let actual = boundaries(" foo ");
-        assert_eq!(vec![(1, Start), (4, End), (5, End)], actual);
+        assert_eq!(vec![(1, Start), (4, End)], actual);
 
         // TODO we should have configurable word separators to allow `_` to not break words if the users wants that
         let actual = boundaries("foo_bar");
-        assert_eq!(vec![(3, Both), (4, Both), (7, End)], actual);
+        assert_eq!(vec![(3, Both), (4, Both)], actual);
         let actual = boundaries("foo___");
-        assert_eq!(vec![(3, Both), (6, End)], actual);
+        assert_eq!(vec![(3, Both)], actual);
+    }
+
+    #[test]
+    fn test_word_boundaries_in_rope() {
+        test_util::setup_test();
+        use WordBoundaryType::*;
+        assert_eq!(
+            vec![(4, End), (5, Start), (8, Both), (11, Both)],
+            find_word_boundaries(&Rope::from(" foo foo..."), 2).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn test_word_boundaries_in_rope_reverse() {
+        test_util::setup_test();
+        use WordBoundaryType::*;
+        assert_eq!(
+            vec![(5, Start), (4, End), (1, Start), (0, Both)],
+            find_word_boundaries_backwards(&Rope::from(" foo foo..."), 7).collect::<Vec<_>>(),
+        );
     }
 }

--- a/crates/bazed-core/src/word_boundary.rs
+++ b/crates/bazed-core/src/word_boundary.rs
@@ -2,7 +2,7 @@ use unicode_general_category::GeneralCategory;
 use xi_rope::Rope;
 
 /// Type of a word-boundary.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub(crate) enum WordBoundaryType {
     /// Indicates the start of a "word"
     Start,
@@ -39,7 +39,7 @@ impl WordBoundaryType {
 
 /// Category of character, loosely derived from the unicode general category defined
 /// in [Unicode Standard Annex #44, Section 5.7.1](http://www.unicode.org/reports/tr44/#General_Category_Values)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum CharCategory {
     /// Any whitespace or lineseparator character
     Whitespace,

--- a/rekuho/src/lib/Portion.svelte
+++ b/rekuho/src/lib/Portion.svelte
@@ -9,7 +9,7 @@
   import { measure as fontMeasure } from "./Font"
   import { state, type CaretPosition } from "./Core"
   import type { Vector2 } from "./LinearAlgebra"
-  import type { Key, KeyInput } from "./Rpc"
+  import type { Key, KeyInput, Modifier } from "./Rpc"
 
   const gutter_width = 50 // maybe should be part of theme, minimum value?
 
@@ -22,8 +22,6 @@
 
   let input: HTMLTextAreaElement
   let container: Element
-
-  const emitKeyboardInput = (key: Key) => onKeyInput({ modifiers: [], key })
 
   // TODO: separate into linear_algebra.ts
   $: view_rect = container && container.getBoundingClientRect()
@@ -74,30 +72,41 @@
   */
 
   const keydown = (ev: KeyboardEvent) => {
-    console.log(ev.key)
+    console.log(ev)
+    const modifiers: Modifier[] = []
+    if (ev.ctrlKey) modifiers.push("ctrl")
+    if (ev.shiftKey) modifiers.push("shift")
+    if (ev.altKey) modifiers.push("alt")
+    if (ev.metaKey) modifiers.push("win")
+
+    let key: Key | null = null
     if (ev.key.length === 1) {
-      emitKeyboardInput({ char: ev.key })
+      key = { char: ev.key }
     }
 
     switch (ev.key) {
       case "Enter":
-        emitKeyboardInput("return")
+        key = "return"
         break
       case "Backspace":
-        emitKeyboardInput("backspace")
+        key = "backspace"
         break
       case "ArrowLeft":
-        emitKeyboardInput("left")
+        key = "left"
         break
       case "ArrowRight":
-        emitKeyboardInput("right")
+        key = "right"
         break
       case "ArrowUp":
-        emitKeyboardInput("up")
+        key = "up"
         break
       case "ArrowDown":
-        emitKeyboardInput("down")
+        key = "down"
         break
+    }
+
+    if (key) {
+      onKeyInput({ modifiers, key })
     }
   }
 


### PR DESCRIPTION
This PR implements word-boundary search, and uses it to implement word-wise movement.
To make that usable, it also makes the frontend include modifier state when sending key events.
