### PR TITLE
move caret when mouse clicks on a character

### DIFF
--- a/crates/bazed-core/src/buffer.rs
+++ b/crates/bazed-core/src/buffer.rs
@@ -4,7 +4,7 @@ use nonempty::{nonempty, NonEmpty};
 use tap::Pipe;
 use xi_rope::{engine::Engine, tree::NodeInfo, DeltaBuilder, Rope, RopeDelta, Transformer};
 
-use self::undo_history::UndoHistory;
+use self::{position::Position, undo_history::UndoHistory};
 use crate::{
     region::{Region, RegionId},
     user_buffer_op::{BufferOp, EditType, Motion, Trajectory},
@@ -12,6 +12,7 @@ use crate::{
     word_boundary,
 };
 
+pub mod position;
 mod undo_history;
 
 /// Stores all the active regions in a buffer.
@@ -358,68 +359,6 @@ fn apply_motion_to_region(
         head: offset,
         tail: if only_move_head { region.tail } else { offset },
         stickyness: region.stickyness,
-    }
-}
-
-/// Position in a [Buffer] by it's line and col.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Position {
-    pub line: usize,
-    pub col: usize,
-}
-
-impl Position {
-    fn from_offset(text: &Rope, offset: usize) -> Self {
-        let line = text.line_of_offset(offset);
-        let col = offset - text.offset_of_line(line);
-        Position { line, col }
-    }
-    /// Turn a position into an offset at that point,
-    /// snapping to the end of the line if the cursors column is further than the line is long.
-    ///
-    /// ```rust
-    /// use bazed_core::buffer::Position;
-    /// use xi_rope::Rope;
-    ///
-    /// let t = Rope::from("1234\n12\n");
-    /// assert_eq!(0, Position { line: 0, col: 0 }.to_offset(&t));
-    /// assert_eq!(3, Position { line: 0, col: 3 }.to_offset(&t));
-    /// assert_eq!(5, Position { line: 1, col: 0 }.to_offset(&t));
-    /// assert_eq!(7, Position { line: 1, col: 10 }.to_offset(&t));
-    /// assert_eq!(8, Position { line: 2, col: 0 }.to_offset(&t));
-    /// assert_eq!(8, Position { line: 2, col: 10 }.to_offset(&t));
-    /// ```
-    pub fn to_offset(self, text: &Rope) -> usize {
-        let line_offset = text.offset_of_line(self.line);
-
-        let naive_offset = if line_offset + self.col >= text.len() {
-            text.len()
-        } else {
-            text.prev_grapheme_offset(line_offset + self.col + 1)
-                .unwrap_or(0)
-        };
-
-        // restrict naive_offset to at max be the end of the given line
-        let last_line = text.line_of_offset(text.len());
-        if self.line == last_line {
-            naive_offset
-        } else {
-            let next_line_offset = text.offset_of_line(self.line + 1);
-            if naive_offset < next_line_offset {
-                naive_offset
-            } else {
-                text.prev_grapheme_offset(next_line_offset)
-                    .unwrap_or(naive_offset)
-            }
-        }
-    }
-
-    pub fn with_line(self, line: usize) -> Self {
-        Self { line, ..self }
-    }
-
-    pub fn with_col(self, col: usize) -> Self {
-        Self { col, ..self }
     }
 }
 

--- a/crates/bazed-core/src/buffer/position.rs
+++ b/crates/bazed-core/src/buffer/position.rs
@@ -1,0 +1,64 @@
+use xi_rope::Rope;
+
+/// Position in a [bazed_core::buffer::Buffer] by it's line and col.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Position {
+    pub line: usize,
+    pub col: usize,
+}
+
+impl Position {
+    pub fn from_offset(text: &Rope, offset: usize) -> Self {
+        let line = text.line_of_offset(offset);
+        let col = offset - text.offset_of_line(line);
+        Position { line, col }
+    }
+
+    /// Turn a position into an offset at that point,
+    /// snapping to the end of the line if the cursors column is further than the line is long.
+    ///
+    /// ```rust
+    /// use bazed_core::buffer::Position;
+    /// use xi_rope::Rope;
+    ///
+    /// let t = Rope::from("1234\n12\n");
+    /// assert_eq!(0, Position { line: 0, col: 0 }.to_offset(&t));
+    /// assert_eq!(3, Position { line: 0, col: 3 }.to_offset(&t));
+    /// assert_eq!(5, Position { line: 1, col: 0 }.to_offset(&t));
+    /// assert_eq!(7, Position { line: 1, col: 10 }.to_offset(&t));
+    /// assert_eq!(8, Position { line: 2, col: 0 }.to_offset(&t));
+    /// assert_eq!(8, Position { line: 2, col: 10 }.to_offset(&t));
+    /// ```
+    pub fn to_offset(self, text: &Rope) -> usize {
+        let line_offset = text.offset_of_line(self.line);
+
+        let naive_offset = if line_offset + self.col >= text.len() {
+            text.len()
+        } else {
+            text.prev_grapheme_offset(line_offset + self.col + 1)
+                .unwrap_or(0)
+        };
+
+        // restrict naive_offset to at max be the end of the given line
+        let last_line = text.line_of_offset(text.len());
+        if self.line == last_line {
+            naive_offset
+        } else {
+            let next_line_offset = text.offset_of_line(self.line + 1);
+            if naive_offset < next_line_offset {
+                naive_offset
+            } else {
+                text.prev_grapheme_offset(next_line_offset)
+                    .unwrap_or(naive_offset)
+            }
+        }
+    }
+
+    pub fn with_line(self, line: usize) -> Self {
+        Self { line, ..self }
+    }
+
+    pub fn with_col(self, col: usize) -> Self {
+        Self { col, ..self }
+    }
+}

--- a/crates/bazed-core/src/buffer/position.rs
+++ b/crates/bazed-core/src/buffer/position.rs
@@ -8,40 +8,77 @@ pub struct Position {
 }
 
 impl Position {
-    pub fn from_offset(text: &Rope, offset: usize) -> Self {
-        let line = text.line_of_offset(offset);
-        let col = offset - text.offset_of_line(line);
-        Position { line, col }
+    pub fn new(line: usize, col: usize) -> Self {
+        Self { line, col }
+    }
+
+    /// Get the position of a given offset in a text.
+    /// Will return `None` if the offset is outside the bounds of the text
+    /// If `offset == text.len()`, will return `text.len()`.
+    pub fn from_offset(text: &Rope, offset: usize) -> Option<Self> {
+        if offset > text.len() {
+            None
+        } else {
+            let line = text.line_of_offset(offset);
+            let col = offset - text.offset_of_line(line);
+            Some(Position { line, col })
+        }
+    }
+
+    /// Turn a position into an offset at that point.
+    /// Return `None` if there is no character at that point.
+    /// When the position points to the exact end of the text, will succeed to yield text.len(),
+    /// as that is a valid character offset, even if it's not a valid character _index_.
+    pub fn to_offset(self, text: &Rope) -> Option<usize> {
+        let last_line = text.line_of_offset(text.len());
+        if self.line > last_line {
+            return None;
+        }
+        let line_offset = text.offset_of_line(self.line);
+        let naive_offset = line_offset + self.col;
+        if naive_offset > text.len() {
+            return None;
+        }
+
+        // This is very carefully ordered to avoid panics in offset_of_line and prev_grapheme_offset
+
+        // Make sure that naive_offset turns out to be in the line it should
+        if self.line == last_line || naive_offset < text.offset_of_line(self.line + 1) {
+            if naive_offset == text.len() {
+                Some(naive_offset)
+            } else {
+                // Snap the naive offset to the start of the grapheme it's in
+                // If there is no previous grapheme, we're probably at the first -> default to 0
+                Some(text.prev_grapheme_offset(naive_offset + 1).unwrap_or(0))
+            }
+        } else {
+            // The naive offset we calculated turned out to be behind the next newline
+            // thus position had a valid line, but the column number was too high
+            None
+        }
     }
 
     /// Turn a position into an offset at that point,
-    /// snapping to the end of the line if the cursors column is further than the line is long.
-    ///
-    /// ```rust
-    /// use bazed_core::buffer::Position;
-    /// use xi_rope::Rope;
-    ///
-    /// let t = Rope::from("1234\n12\n");
-    /// assert_eq!(0, Position { line: 0, col: 0 }.to_offset(&t));
-    /// assert_eq!(3, Position { line: 0, col: 3 }.to_offset(&t));
-    /// assert_eq!(5, Position { line: 1, col: 0 }.to_offset(&t));
-    /// assert_eq!(7, Position { line: 1, col: 10 }.to_offset(&t));
-    /// assert_eq!(8, Position { line: 2, col: 0 }.to_offset(&t));
-    /// assert_eq!(8, Position { line: 2, col: 10 }.to_offset(&t));
-    /// ```
-    pub fn to_offset(self, text: &Rope) -> usize {
+    /// snapping to the end of the line if the column is further than the line is long
+    /// and snapping to the last line if the position in a line that doesn't exist.
+    pub fn to_offset_snapping(mut self, text: &Rope) -> usize {
+        let last_line = text.line_of_offset(text.len());
+        // snap to the last line
+        self.line = self.line.min(last_line);
         let line_offset = text.offset_of_line(self.line);
 
-        let naive_offset = if line_offset + self.col >= text.len() {
+        let naive_offset = line_offset + self.col;
+        let naive_offset = if naive_offset >= text.len() {
+            // if we're at the end of the text, snap to end of text here
             text.len()
         } else {
-            text.prev_grapheme_offset(line_offset + self.col + 1)
-                .unwrap_or(0)
+            text.prev_grapheme_offset(naive_offset + 1).unwrap_or(0)
         };
 
         // restrict naive_offset to at max be the end of the given line
-        let last_line = text.line_of_offset(text.len());
         if self.line == last_line {
+            // we know that the offset is in bounds of the text,
+            // as snapped it to the text length before
             naive_offset
         } else {
             let next_line_offset = text.offset_of_line(self.line + 1);
@@ -60,5 +97,103 @@ impl Position {
 
     pub fn with_col(self, col: usize) -> Self {
         Self { col, ..self }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use xi_rope::Rope;
+
+    use super::*;
+    use crate::test_util;
+
+    #[test]
+    fn test_to_offset_valid() {
+        // Test that both to_offset and to_offset_snapping work for all valid positions
+        // and yield the same value
+        let test_to_offset = |t, expected, p: Position| {
+            assert_eq!(Some(expected), p.to_offset(t), "to_offset non-snapping");
+            assert_eq!(expected, p.to_offset_snapping(t), "to_offset_snapping");
+        };
+
+        test_util::setup_test();
+        let t = Rope::from("");
+        test_to_offset(&t, 0, Position::new(0, 0));
+
+        let t = Rope::from("hello");
+        test_to_offset(&t, 5, Position::new(0, 5));
+
+        let t = Rope::from("foo\nx\nbar\n\n");
+        test_to_offset(&t, 0, Position::new(0, 0));
+        test_to_offset(&t, 3, Position::new(0, 3));
+        test_to_offset(&t, 4, Position::new(1, 0));
+        test_to_offset(&t, 5, Position::new(1, 1));
+        test_to_offset(&t, 6, Position::new(2, 0));
+        test_to_offset(&t, 10, Position::new(3, 0));
+        test_to_offset(&t, 11, Position::new(4, 0));
+    }
+
+    #[test]
+    fn test_to_offset_snapping() {
+        test_util::setup_test();
+        let t = Rope::from("");
+        assert_eq!(0, Position::new(10, 0).to_offset_snapping(&t));
+        assert_eq!(0, Position::new(10, 10).to_offset_snapping(&t));
+
+        let t = Rope::from("hello");
+        assert_eq!(5, Position::new(0, 10).to_offset_snapping(&t));
+        assert_eq!(2, Position::new(10, 2).to_offset_snapping(&t));
+
+        let t = Rope::from("foo\n\nbar");
+        assert_eq!(3, Position::new(0, 10).to_offset_snapping(&t));
+        assert_eq!(4, Position::new(1, 10).to_offset_snapping(&t));
+        assert_eq!(8, Position::new(2, 10).to_offset_snapping(&t));
+        assert_eq!(8, Position::new(10, 10).to_offset_snapping(&t));
+    }
+
+    #[test]
+    fn test_from_offset_valid() {
+        test_util::setup_test();
+
+        let t = Rope::from("hello");
+        assert_eq!(Some(Position::new(0, 5)), Position::from_offset(&t, 5));
+
+        let t = Rope::from("foo\nx\nbar\n\n");
+        assert_eq!(Some(Position::new(0, 0)), Position::from_offset(&t, 0));
+        assert_eq!(Some(Position::new(0, 3)), Position::from_offset(&t, 3));
+        assert_eq!(Some(Position::new(1, 0)), Position::from_offset(&t, 4));
+        assert_eq!(Some(Position::new(1, 1)), Position::from_offset(&t, 5));
+        assert_eq!(Some(Position::new(2, 0)), Position::from_offset(&t, 6));
+        assert_eq!(Some(Position::new(3, 0)), Position::from_offset(&t, 10));
+        assert_eq!(Some(Position::new(4, 0)), Position::from_offset(&t, 11));
+    }
+
+    #[test]
+    fn test_to_offset_invalid() {
+        test_util::setup_test();
+
+        let t = Rope::from("hello");
+        assert_eq!(None, Position::new(0, 10).to_offset(&t));
+
+        let t = Rope::from("foo\nx\nbar\n\n");
+        assert_eq!(Some(0), Position::new(0, 0).to_offset(&t));
+        assert_eq!(Some(3), Position::new(0, 3).to_offset(&t));
+        assert_eq!(Some(4), Position::new(1, 0).to_offset(&t));
+        assert_eq!(Some(5), Position::new(1, 1).to_offset(&t));
+        assert_eq!(Some(6), Position::new(2, 0).to_offset(&t));
+        assert_eq!(Some(10), Position::new(3, 0).to_offset(&t));
+        assert_eq!(Some(11), Position::new(4, 0).to_offset(&t));
+    }
+
+    #[test]
+    fn test_from_offset_invalid() {
+        test_util::setup_test();
+
+        let t = Rope::from("");
+        assert_eq!(None, Position::from_offset(&t, 1));
+
+        let t = Rope::from("hello");
+        assert_eq!(None, Position::from_offset(&t, 6));
+        assert_eq!(None, Position::from_offset(&t, 6000));
     }
 }

--- a/rekuho/src/lib/Portion.svelte
+++ b/rekuho/src/lib/Portion.svelte
@@ -9,7 +9,7 @@
   import { measure as fontMeasure } from "./Font"
   import { state, type CaretPosition } from "./Core"
   import type { Vector2 } from "./LinearAlgebra"
-  import type { Key, KeyInput } from "./Rpc"
+  import type { Key, KeyInput, Modifier } from "./Rpc"
 
   const gutter_width = 50 // maybe should be part of theme, minimum value?
 
@@ -22,8 +22,6 @@
 
   let input: HTMLTextAreaElement
   let container: Element
-
-  const emitKeyboardInput = (key: Key) => onKeyInput({ modifiers: [], key })
 
   // TODO: separate into linear_algebra.ts
   $: view_rect = container && container.getBoundingClientRect()
@@ -74,30 +72,41 @@
   */
 
   const keydown = (ev: KeyboardEvent) => {
-    console.log(ev.key)
+    console.log(ev)
+    const modifiers: Modifier[] = []
+    if (ev.ctrlKey) modifiers.push("ctrl")
+    if (ev.shiftKey) modifiers.push("shift")
+    if (ev.altKey) modifiers.push("alt")
+    if (ev.metaKey) modifiers.push("win")
+
+    let key: Key | null = null
     if (ev.key.length === 1) {
-      emitKeyboardInput({ char: ev.key })
+      key = { char: ev.key }
     }
 
     switch (ev.key) {
       case "Enter":
-        emitKeyboardInput("return")
+        key = "return"
         break
       case "Backspace":
-        emitKeyboardInput("backspace")
+        key = "backspace"
         break
       case "ArrowLeft":
-        emitKeyboardInput("left")
+        key = "left"
         break
       case "ArrowRight":
-        emitKeyboardInput("right")
+        key = "right"
         break
       case "ArrowUp":
-        emitKeyboardInput("up")
+        key = "up"
         break
       case "ArrowDown":
-        emitKeyboardInput("down")
+        key = "down"
         break
+    }
+
+    if (key) {
+      onKeyInput({ modifiers, key })
     }
   }
 


### PR DESCRIPTION
This PR implements moving the cursor to where the mouse clicked, thus fixes #68.
For that, we factor out the Position struct into a separate module and add
a thorough set of tests to verify it's behavior.
There is now also a distinction between `to_offset` and `to_offset_snapping`.

**this PR is built on top of #71, which should get merged first**