### PR TITLE
feat(view): keep carets on screen when moving out of viewport

### DIFF
--- a/crates/bazed-core/src/buffer.rs
+++ b/crates/bazed-core/src/buffer.rs
@@ -81,6 +81,14 @@ impl Buffer {
                 .expect("Caret stored in BufferRegions was not a valid offset into the buffer")
         })
     }
+    pub fn primary_caret(&self) -> &Region {
+        self.regions.primary_caret()
+    }
+
+    pub fn primary_caret_position(&self) -> Position {
+        Position::from_offset(&self.text, self.primary_caret().head)
+            .expect("Caret stored in BufferRegions was not a valid offset into the buffer")
+    }
 
     pub fn start_building_delta(&self) -> DeltaBuilder<RopeInfo> {
         DeltaBuilder::new(self.text.len())
@@ -525,7 +533,7 @@ mod test {
         b.move_carets(&vp, Motion::TopOfViewport);
         assert_eq!(1, b.all_caret_positions().first().line);
         b.move_carets(&vp, Motion::BottomOfViewport);
-        assert_eq!(3, b.all_caret_positions().first().line);
+        assert_eq!(2, b.all_caret_positions().first().line);
 
         // verify we don't die if the bottom of the viewport is below the last line
         vp.height = 100;

--- a/crates/bazed-core/src/buffer/buffer_regions.rs
+++ b/crates/bazed-core/src/buffer/buffer_regions.rs
@@ -93,6 +93,10 @@ impl BufferRegions {
         self.make_carets_consistent()
     }
 
+    pub(super) fn primary_caret(&self) -> &Region {
+        self.regions.get(&self.primary_caret_id).unwrap()
+    }
+
     /// Add a new caret and return the generated id.
     ///
     /// Note that the caret may imediately get merged into another region.

--- a/crates/bazed-core/src/view.rs
+++ b/crates/bazed-core/src/view.rs
@@ -35,6 +35,7 @@ impl View {
 
 /// Information about which part of a [crate::buffer::Buffer] is visible to the client.
 /// Currently only vertical position and height is considered.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Viewport {
     /// Index of the first line shown in the viewport
     pub first_line: usize,
@@ -55,8 +56,47 @@ impl Viewport {
             height: 100_000_000,
         }
     }
-    /// first and last line shown in the viewport
+    /// last line shown in the viewport
     pub fn last_line(&self) -> usize {
-        self.first_line + self.height
+        (self.first_line + self.height).saturating_sub(1)
+    }
+
+    /// Move the viewport such that the given line_nr is in view, and
+    /// attempt to keep it a minimum of `scroll_off` lines from the viewport edges
+    /// as long as we're not at the start of the file
+    pub fn with_line_in_view(&self, line_nr: usize, scroll_off: usize) -> Self {
+        let mut vp = self.clone();
+        vp.first_line = if line_nr < vp.first_line + scroll_off {
+            line_nr.saturating_sub(scroll_off)
+        } else if line_nr > vp.last_line().saturating_sub(scroll_off) {
+            let new_last_line = line_nr + scroll_off;
+            new_last_line.saturating_sub(vp.height - 1)
+        } else {
+            vp.first_line
+        };
+        vp
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Viewport;
+    use crate::test_util;
+
+    #[test]
+    fn test_scroll_line_into_view() {
+        test_util::setup_test();
+        assert_eq!(
+            Viewport::new(0, 10),
+            Viewport::new(0, 10).with_line_in_view(0, 0)
+        );
+        assert_eq!(
+            Viewport::new(0, 10),
+            Viewport::new(2, 10).with_line_in_view(2, 2)
+        );
+        assert_eq!(
+            Viewport::new(5, 10),
+            Viewport::new(2, 10).with_line_in_view(12, 2)
+        );
     }
 }


### PR DESCRIPTION
This PR implements moving the viewport when the cursor moves off screen, aiming to keep the cursor on screen.