### PR TITLE
refactor(rpc): simpify RPC interface

### DIFF
--- a/crates/bazed-core/src/view.rs
+++ b/crates/bazed-core/src/view.rs
@@ -3,12 +3,9 @@ use uuid::Uuid;
 use crate::document::DocumentId;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, derive_more::Display, derive_more::Into)]
-pub struct ViewId(Uuid);
+pub struct ViewId(pub Uuid);
 
 impl ViewId {
-    pub(crate) fn from_uuid(uuid: Uuid) -> Self {
-        Self(uuid)
-    }
     pub(crate) fn gen() -> Self {
         Self(Uuid::new_v4())
     }

--- a/crates/bazed-rpc/src/core_proto.rs
+++ b/crates/bazed-rpc/src/core_proto.rs
@@ -18,37 +18,32 @@ pub struct CaretPosition {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ViewData {
+    pub first_line: usize,
+    pub text: Vec<String>,
+    /// caret positions are absolute
+    pub carets: Vec<CaretPosition>,
+    pub vim_mode: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "method", content = "params")]
 pub enum ToFrontend {
-    OpenDocument {
-        document_id: Uuid,
+    /// Sent when a new view should be opened.
+    OpenView {
+        view_id: Uuid,
         path: Option<PathBuf>,
-        text: String,
+        view_data: ViewData,
     },
     /// Sent whenever anything in the view changed, i.e. the content,
     /// the viewport, or a caret position
-    UpdateView {
-        view_id: Uuid,
-        first_line: usize,
-        height: usize,
-        text: Vec<String>,
-        /// caret positions are absolute
-        carets: Vec<CaretPosition>,
-        vim_mode: String,
-    },
-    /// Response to the [ToBackend::ViewOpened] request
-    ViewOpenedResponse {
-        request_id: RequestId,
-        view_id: Uuid,
-    },
+    UpdateView { view_id: Uuid, view_data: ViewData },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "method", content = "params")]
 pub enum ToBackend {
-    SaveDocument {
-        document_id: Uuid,
-    },
     KeyPressed {
         view_id: Uuid,
         input: KeyInput,
@@ -69,11 +64,6 @@ pub enum ToBackend {
     /// i.e. because the window was resized or the user scrolled.
     ViewportChanged {
         view_id: Uuid,
-        height: usize,
-    },
-    ViewOpened {
-        request_id: RequestId,
-        document_id: Uuid,
         height: usize,
     },
 }

--- a/node_packages/bazed-svelte/src/lib/core.ts
+++ b/node_packages/bazed-svelte/src/lib/core.ts
@@ -1,25 +1,22 @@
 import { writable } from "svelte/store"
 
+export type Uuid = string
+export type ViewId = Uuid
 export type CaretPosition = { line: number; col: number }
 
 /** cached view state from backend */
 export type State = {
-  documents: { [id: string]: { path: string | null } }
-  views: { [id: string]: ViewState }
-}
-
-export type ViewState = {
-  document: string
-  lines: string[]
-  firstLine: number
-  height: number
-  carets: CaretPosition[]
+  views: {
+    [id: ViewId]:
+      | undefined
+      | {
+          filePath: string | null
+          lines: string[]
+          firstLine: number
+          carets: CaretPosition[]
+        }
+  }
 }
 
 /** store, holding cached state from backend */
-export const state = writable<State>({ documents: {}, views: {} })
-
-/** update stored cached state */
-export const updateState = <K extends keyof State>(field: K, value: State[K]) => {
-  state.update((current) => ({ ...current, [field]: value }))
-}
+export const state = writable<State>({ views: {} })


### PR DESCRIPTION
removes OpenDocument and the whole ViewOpenedResponse stuff,
as there's no reason the frontend should be the one initiating
a view-open.
