### PR TITLE
ci: stop advisories from being an error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,12 +19,28 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup rust toolchain
       run: rustup show
-    - uses: EmbarkStudios/cargo-deny-action@v1
     - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo test --workspace --all-features --no-run
     - name: Run tests
       run: cargo test --workspace --all-features
+
+  cargo-deny:
+    name: Cargo deny
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check ${{ matrix.checks }}
 
   rehuko-lint:
     name: Svelte formatting test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,5 @@
 name: CI
-on:
-  pull_request:
-  push:
+on: [pull_request, push]
 
 env:
   CI: 1


### PR DESCRIPTION
- style(ci): use short-hand syntax for `on`
- ci: prevent rust advisories from suddenly failing CI
