### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,9 +2878,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ unicode-general-category = "0.6.0"
 nonempty = "0.8.1"
 
 futures = { version = "0.3.25", default-features = false, features = ["std"] }
-tokio = { version = "1.23.0", features = ["rt", "net", "macros", "time", "sync"] }
+tokio = { version = "1.24.1", features = ["rt", "net", "macros", "time", "sync"] }
 
 bazed-rpc = { path = "crates/bazed-rpc", version = "0.0.0" }
 bazed-core = { path = "crates/bazed-core", version = "0.0.0" }


### PR DESCRIPTION
This fixes RUSTSEC-2023-0001 for us.
