### PR TITLE
Add problem matcher

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
     - name: Setup rust toolchain
       run: rustup show
     - uses: Swatinem/rust-cache@v2
+    - uses: r7kamura/rust-problem-matchers@v1
     - name: Build
       run: cargo test --workspace --all-features --no-run
     - name: Run tests


### PR DESCRIPTION
This PR adds rust-problem-matchers to the ci workflow, which should highlight
CI messages in the code.
I also include a commit that should cause several CI failures, to test this functionality.
